### PR TITLE
Feature/dry transaction 0.10 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     dry-mutations (1.3.2)
       activesupport (>= 3.2, < 5)
-      dry-transaction (~> 0.9, < 0.10)
+      dry-transaction (~> 0.10)
       dry-validation (~> 0.10)
       hashie (~> 3)
       mutations (~> 0.8)
@@ -48,7 +48,7 @@ GEM
     dry-monads (0.3.1)
       dry-core
       dry-equalizer
-    dry-transaction (0.9.0)
+    dry-transaction (0.10.0)
       dry-container (>= 0.2.8)
       dry-matcher (>= 0.5.0)
       dry-monads (>= 0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dry-mutations (1.2.0)
+    dry-mutations (1.2.1)
       activesupport (>= 3.2, < 5)
       dry-transaction (~> 0.10)
       dry-validation (~> 0.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dry-mutations (1.3.2)
+    dry-mutations (1.2.0)
       activesupport (>= 3.2, < 5)
       dry-transaction (~> 0.10)
       dry-validation (~> 0.10)

--- a/README.md
+++ b/README.md
@@ -339,6 +339,9 @@ Bug reports are very welcome!
 
 ## Changelog
 
+#### 1.1.0
+More handy `chain`s, better `dry-rb` integration, improvements.
+
 #### 0.99.1
 Support for direct input parameters invocation. 100%-compatibility with `mutations`:
 
@@ -347,9 +350,6 @@ def validate # input ≡ { date: nil }
   date < Date.now
 end
 ```
-
-#### 1.1.0
-More handy `chain`s, better `dry-rb` integration, improvements.
 
 #### 0.99.0
 Support for `default:` guard. 99%-compatibility with `mutations`

--- a/dry-mutations.gemspec
+++ b/dry-mutations.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hashie', '~> 3'
 
   spec.add_dependency 'dry-validation', '~> 0.10'
-  spec.add_dependency 'dry-transaction', '~> 0.9', '< 0.10'
+  spec.add_dependency 'dry-transaction', '~> 0.10'
 end

--- a/lib/dry/mutations.rb
+++ b/lib/dry/mutations.rb
@@ -5,6 +5,8 @@ require 'dry-transaction'
 require 'dry-matcher'
 require 'dry-monads'
 
+require 'dry/mutations/monkeypatches'
+
 require 'dry/mutations/version'
 require 'dry/mutations/utils'
 require 'dry/mutations/monkeypatches'

--- a/lib/dry/mutations/monkeypatches.rb
+++ b/lib/dry/mutations/monkeypatches.rb
@@ -8,4 +8,34 @@ class Dry::Logic::Rule::Value < Dry::Logic::Rule
     predicate.args.last rescue nil
   end
 end
+
+module Dry
+  module Transaction
+    class OperationResolver < Module # :nodoc:
+      def initialize(container)
+        module_exec(container) do
+          define_method :initialize do |**kwargs|
+            super(**kwargs)
+          end
+        end
+      end
+    end
+  end
+end
+
+module Dry
+  module Transaction
+    class Step # :nodoc:
+      def initialize(step_adapter, step_name, operation_name, operation, options, call_args = [])
+        @step_adapter = step_adapter
+        @step_name = step_name
+        @operation_name = operation_name
+        @operation = operation
+        @operation ||= @operation_name if @operation_name.respond_to?(:call)
+        @options = options
+        @call_args = call_args
+      end
+    end
+  end
+end
 # rubocop:enable Style/ClassAndModuleChildren

--- a/lib/dry/mutations/transactions/dsl.rb
+++ b/lib/dry/mutations/transactions/dsl.rb
@@ -36,8 +36,8 @@ module Dry
               container: ::Dry::Mutations::Transactions::Container,
               step_adapters: StepAdapters
             )
-            class_eval(&λ) if λ
-            # instance_eval(&λ) if λ
+            # class_eval(&λ) if λ
+            module_eval(&λ) if λ
           end.new.tap do |transaction|
             singleton_class.send :define_method, :call do |*input|
               transaction.(Utils.RawInputs(*input))

--- a/lib/dry/mutations/transactions/dsl.rb
+++ b/lib/dry/mutations/transactions/dsl.rb
@@ -25,18 +25,20 @@ module Dry
         end
         # rubocop:enable Style/MultilineIfModifier
 
-        def chain **params
+        def chain **params, &λ
           return enum_for(:chain) unless block_given? # FIXME: Needed? Works? Remove?
 
           # rubocop:disable Style/VariableNumber
           λ = Proc.new
 
-          @transaction = ::Dry.Transaction(
-            container: ::Dry::Mutations::Transactions::Container,
-            step_adapters: StepAdapters
-          ) do
-            instance_eval(&λ)
-          end.tap do |transaction|
+          @transaction = Class.new do
+            include ::Dry::Transaction(
+              container: ::Dry::Mutations::Transactions::Container,
+              step_adapters: StepAdapters
+            )
+            class_eval(&λ) if λ
+            # instance_eval(&λ) if λ
+          end.new.tap do |transaction|
             singleton_class.send :define_method, :call do |*input|
               transaction.(Utils.RawInputs(*input))
             end

--- a/lib/dry/mutations/transactions/step_adapters.rb
+++ b/lib/dry/mutations/transactions/step_adapters.rb
@@ -1,3 +1,5 @@
+require 'active_support'
+
 module Dry
   module Mutations
     module Transactions # :nodoc:
@@ -17,7 +19,7 @@ module Dry
           end
 
           def call(step, *args, input)
-            step.operation.(input, *args, &step.block)
+            step.operation.(input, *args)
           end
         end
 

--- a/lib/dry/mutations/transactions/step_adapters/chain.rb
+++ b/lib/dry/mutations/transactions/step_adapters/chain.rb
@@ -6,16 +6,16 @@ module Dry
       #   which should return the step’s result wrapped in an `Either` object.
       # This one is a wrapper for neted chains
       class Chain < StepAdapters::Move
-        def call(step, *args, input)
-          if step.block
-            Class.new do
-              extend ::Dry::Mutations::Transactions::DSL
-              chain(&step.block)
-            end.(input, *args)
-          else
-            super
-          end
-        end
+        # def call(step, *args, input)
+        #   if step.block
+        #     Class.new do
+        #       extend ::Dry::Mutations::Transactions::DSL
+        #       chain(&step.block)
+        #     end.(input, *args)
+        #   else
+        #     super
+        #   end
+        # end
       end
     end
   end

--- a/lib/dry/mutations/version.rb
+++ b/lib/dry/mutations/version.rb
@@ -1,5 +1,5 @@
 module Dry
   module Mutations
-    VERSION = '1.3.2'.freeze
+    VERSION = '1.2.0'.freeze
   end
 end

--- a/lib/dry/mutations/version.rb
+++ b/lib/dry/mutations/version.rb
@@ -1,5 +1,5 @@
 module Dry
   module Mutations
-    VERSION = '1.2.0'.freeze
+    VERSION = '1.2.1'.freeze
   end
 end

--- a/spec/dry/mutations/transaction_spec.rb
+++ b/spec/dry/mutations/transaction_spec.rb
@@ -110,9 +110,7 @@ describe Dry::Mutations::Transactions do
         chain do
           tranquilo c1
           chain child
-          chain do
-            validate c3
-          end
+          chain c3
         end
       end
     end


### PR DESCRIPTION
=== DO NOT MERGE THIS PULL REQUEST ===

I am unsure if we want to migrate to `0.10.0` of `dry-transactions`. It seems to be _worse_. It does not accept blocks within steps. It basically sucks.